### PR TITLE
popup.html updated

### DIFF
--- a/html/popup.html
+++ b/html/popup.html
@@ -12,7 +12,7 @@
             </div>
     
             <div class="row-fluid">
-                <span>Select a language: </span>
+                <label for="selectId">Select a language: </label>
                 <select id="selectId" class="box selectpicker" data-show-subtext="true" data-live-search="true">
                     <option value ="ja" data-subtext="ja">日本語</option>
                     <option value ="vi" data-subtext="vi">Tiếng Việt</option>


### PR DESCRIPTION
Use of "label" in place of "span" would be more suitable. As it will highlight the "select" when clicked on "Select a language".